### PR TITLE
Add optional Hunter support to provide dependencies

### DIFF
--- a/SetupHunter.cmake
+++ b/SetupHunter.cmake
@@ -1,0 +1,7 @@
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+
+set(HUNTER_PACKAGES Boost nlohmann_json)
+
+include(FetchContent)
+FetchContent_Declare(SetupHunter GIT_REPOSITORY https://github.com/cpp-pm/gate)
+FetchContent_MakeAvailable(SetupHunter)


### PR DESCRIPTION
Use https://github.com/cpp-pm/hunter as optional pure CMake dependency manager. To wake up Hunter and tell it to provide the dependencies for your project just add `-DHUNTER_ENABLED=ON` to your cmake configuration line