### PR TITLE
 Add install target and export cmake config 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,15 @@ endif()
 find_package(Boost 1.56 REQUIRED)
 
 add_library(fuser INTERFACE)
+add_library(fuser::fuser ALIAS fuser)
 
 target_sources(fuser INTERFACE
-	include/fuser/fuser.hpp
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/fuser/fuser.hpp>
 )
 
 target_include_directories(fuser INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}/include
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 if(FUSER_ONLY_CXX_11)
@@ -59,4 +61,51 @@ target_link_libraries(fuser INTERFACE
 
 if(FUSER_BUILD_TESTS)
 	add_subdirectory(test)
+endif()
+
+include(GNUInstallDirs)
+set(config_install_dir "${CMAKE_INSTALL_DATADIR}/cmake/fuser")
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(version_config "${generated_dir}/fuserConfigVersion.cmake")
+set(project_config "${generated_dir}/fuserConfig.cmake")
+set(TARGETS_EXPORT_NAME "fuserTargets")
+set(namespace "fuser::")
+
+include(CMakePackageConfigHelpers)
+#write_basic_package_version_file(
+#	"${version_config}"
+#	VERSION ${PROJECT_VERSION}
+#	COMPATIBILITY AnyNewerVersion
+#)
+configure_package_config_file(
+	"cmake/Config.cmake.in"
+	"${project_config}"
+	INSTALL_DESTINATION "${config_install_dir}"
+)
+install(
+	TARGETS fuser
+	EXPORT "${TARGETS_EXPORT_NAME}"
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/fuser"
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(FILES "${project_config}" #"${version_config}"
+	DESTINATION "${config_install_dir}"
+)
+install(
+	EXPORT "${TARGETS_EXPORT_NAME}"
+	NAMESPACE "${namespace}"
+	DESTINATION "${config_install_dir}")
+
+# uninstall target
+if(NOT TARGET uninstall)
+	configure_file(
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+		"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+		IMMEDIATE
+		@ONLY)
+	add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif()

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET nlohmann_json::nlohmann_json)
+	find_dependency(nlohmann_json)
+endif()
+if(NOT TARGET Boost::boost)
+	find_dependency(Boost)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
Add an alias fuser::fuster to match the installed target name. Then the
usage in the downstream project is the same for subdirectory and
installed target.

Create and install a fuserConfig.cmake file for `find_package(fuser)`.
The config target searches for dependencies if the required targets are
not yet present.

Install the header file.

The second commit is the optional Hunter dependency manager support also provided as separate PR https://github.com/Xeverous/fuser/pull/1